### PR TITLE
Add Budgets for Multiple Months

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -1,9 +1,14 @@
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import org.intellij.lang.annotations.JdkConstants.HorizontalAlignment
 import viewmodels.BaseViewModel
 import views.EditBucketView
 import views.EditTransactionView
@@ -16,12 +21,15 @@ fun App(component: BaseViewModel) {
     val child = component.callstack.subscribeAsState()
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
-            when(child.value.active.instance) {
-                is BaseViewModel.Child.ListChild -> ContainerView(component = (child.value.active.instance as BaseViewModel.Child.ListChild).component)
-                is BaseViewModel.Child.BucketDetailsChild -> TransactionsView(component = (child.value.active.instance as BaseViewModel.Child.BucketDetailsChild).component)
-                is BaseViewModel.Child.AddTransactionChild -> EditTransactionView(component = (child.value.active.instance as BaseViewModel.Child.AddTransactionChild).component)
-                is BaseViewModel.Child.EditBucketChild -> EditBucketView(component = (child.value.active.instance as BaseViewModel.Child.EditBucketChild).component)
-                is BaseViewModel.Child.TransactionDetailsChild -> TransactionDetailView(component = (child.value.active.instance as BaseViewModel.Child.TransactionDetailsChild).component)
+            Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(text = "Budgyt", fontSize = 48.sp)
+                when(child.value.active.instance) {
+                    is BaseViewModel.Child.ListChild -> ContainerView(component = (child.value.active.instance as BaseViewModel.Child.ListChild).component)
+                    is BaseViewModel.Child.BucketDetailsChild -> TransactionsView(component = (child.value.active.instance as BaseViewModel.Child.BucketDetailsChild).component)
+                    is BaseViewModel.Child.AddTransactionChild -> EditTransactionView(component = (child.value.active.instance as BaseViewModel.Child.AddTransactionChild).component)
+                    is BaseViewModel.Child.EditBucketChild -> EditBucketView(component = (child.value.active.instance as BaseViewModel.Child.EditBucketChild).component)
+                    is BaseViewModel.Child.TransactionDetailsChild -> TransactionDetailView(component = (child.value.active.instance as BaseViewModel.Child.TransactionDetailsChild).component)
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/viewmodels/BudgetOverviewViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/viewmodels/BudgetOverviewViewModel.kt
@@ -164,15 +164,21 @@ class BudgetOverviewViewModel(componentContext: ComponentContext, database: budg
     }
 
     private fun listComponent(componentContext: ComponentContext): ListComponent {
-        return DefaultListComponent(componentContext = componentContext,
-            model = MutableValue(cache.value[1]),
+        return DefaultListComponent(
+            componentContext = componentContext,
+            model = MutableValue(cache.value),
+            currentDate = currentDate,
             onItemSelected = { bucket ->
                 navigation.push(configuration = Config.Details(bucket))
             },
             onAddTransactionSelected = { transaction ->
                 navigation.push(configuration = Config.Add(transaction))
             },
-            onAddBucketSelected = { navigation.push(configuration = Config.AddEditBucket(bucket = null)) }
+            onAddBucketSelected = { navigation.push(configuration = Config.AddEditBucket(bucket = null)) },
+            onMonthChanged = { newMonth ->
+                println("New month: $newMonth")
+                currentDate.update { newMonth }
+            }
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/viewmodels/ListComponent.kt
+++ b/composeApp/src/commonMain/kotlin/viewmodels/ListComponent.kt
@@ -20,24 +20,25 @@ import models.Transaction
 import java.util.UUID
 
 interface ListComponent {
-    val model: MutableValue<Array<List<Container>>>
+    val model: MutableValue<List<Container>>
     val currentDate: MutableValue<LocalDate>
     fun onItemClicked(item: Bucket)
     fun onAddTransactionButtonClicked()
 
     fun navigateToAddBucketSelected()
 
-    fun changeMonth(oldPageNumber: Int, newPageNumber: Int)
+    fun updateCurrentDate(month: Int, year: Int)
+
 }
 
 class DefaultListComponent(
     componentContext: ComponentContext,
     override val currentDate: MutableValue<LocalDate>,
-    override val model: MutableValue<Array<List<Container>>>,
+    override val model: MutableValue<List<Container>>,
     private val onItemSelected: (item: Bucket) -> Unit,
     private val onAddTransactionSelected: (transaction: Transaction?) -> Unit,
     private val onAddBucketSelected: () -> Unit,
-    private val onMonthChanged: (LocalDate) -> Unit
+    private val onUpdateCurrentDate: (month: Int, year: Int) -> Unit
 ) : ListComponent, ComponentContext by componentContext {
     override fun onItemClicked(item: Bucket) {
         onItemSelected(item)
@@ -51,12 +52,7 @@ class DefaultListComponent(
         onAddBucketSelected()
     }
 
-    override fun changeMonth(oldPageNumber: Int, newPageNumber: Int) {
-        val newMonth: LocalDate = when(newPageNumber - oldPageNumber) {
-            1 -> currentDate.value.plus(1, DateTimeUnit.MONTH)
-            -1 -> currentDate.value.minus(1, DateTimeUnit.MONTH)
-            else -> currentDate.value
-        }
-        onMonthChanged(newMonth)
+    override fun updateCurrentDate(month: Int, year: Int) {
+        onUpdateCurrentDate(month, year)
     }
 }

--- a/composeApp/src/commonMain/kotlin/viewmodels/ListComponent.kt
+++ b/composeApp/src/commonMain/kotlin/viewmodels/ListComponent.kt
@@ -6,7 +6,12 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.update
 import com.technology626.budgyt.budgyt
 import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimePeriod
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
 import kotlinx.datetime.todayIn
 import models.Bucket
 import models.BucketType
@@ -15,19 +20,24 @@ import models.Transaction
 import java.util.UUID
 
 interface ListComponent {
-    val model: MutableValue<List<Container>>
+    val model: MutableValue<Array<List<Container>>>
+    val currentDate: MutableValue<LocalDate>
     fun onItemClicked(item: Bucket)
     fun onAddTransactionButtonClicked()
 
     fun navigateToAddBucketSelected()
+
+    fun changeMonth(oldPageNumber: Int, newPageNumber: Int)
 }
 
 class DefaultListComponent(
     componentContext: ComponentContext,
-    override val model: MutableValue<List<Container>>,
+    override val currentDate: MutableValue<LocalDate>,
+    override val model: MutableValue<Array<List<Container>>>,
     private val onItemSelected: (item: Bucket) -> Unit,
     private val onAddTransactionSelected: (transaction: Transaction?) -> Unit,
     private val onAddBucketSelected: () -> Unit,
+    private val onMonthChanged: (LocalDate) -> Unit
 ) : ListComponent, ComponentContext by componentContext {
     override fun onItemClicked(item: Bucket) {
         onItemSelected(item)
@@ -39,5 +49,14 @@ class DefaultListComponent(
 
     override fun navigateToAddBucketSelected() {
         onAddBucketSelected()
+    }
+
+    override fun changeMonth(oldPageNumber: Int, newPageNumber: Int) {
+        val newMonth: LocalDate = when(newPageNumber - oldPageNumber) {
+            1 -> currentDate.value.plus(1, DateTimeUnit.MONTH)
+            -1 -> currentDate.value.minus(1, DateTimeUnit.MONTH)
+            else -> currentDate.value
+        }
+        onMonthChanged(newMonth)
     }
 }

--- a/composeApp/src/commonMain/kotlin/views/ContainerView.kt
+++ b/composeApp/src/commonMain/kotlin/views/ContainerView.kt
@@ -1,16 +1,24 @@
 package views
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.Button
 import androidx.compose.material.Card
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -18,46 +26,66 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import components.BucketCard
+import kotlinx.coroutines.flow.collect
 import models.BucketType
 import viewmodels.ListComponent
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ContainerView(component: ListComponent) { //Really, this is a bucket of buckets.
     val bucketsState = component.model.subscribeAsState()
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        //This component should also hold the state for the inner internal items
-        LazyColumn {
-            items(bucketsState.value) { container ->
-                Text(
-                    text = when (container.containerType) {
-                        BucketType.INFLOW -> "Inflow"
-                        BucketType.OUTFLOW -> "Outflow"
-                        BucketType.FUND -> "Fund"
-                    },
-                    fontSize = 32.sp,
-                    modifier = Modifier.padding(8.dp)
-                )
-                if (container.buckets.isEmpty()) {
-                    Card(
-                        modifier = Modifier.fillMaxWidth(0.8f)
-                            .padding(16.dp).height(IntrinsicSize.Min), elevation = 4.dp
-                    ) {
+    val dateState = component.currentDate.subscribeAsState()
+    val oldPageNumber = remember { mutableStateOf(1) }
+    val pagerState = rememberPagerState(initialPage = 1, pageCount = { 3 })
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }.collect { page ->
+            component.changeMonth(oldPageNumber.value, page)
+            oldPageNumber.value = page
+        }
+    }
+    Column(modifier = Modifier.fillMaxHeight(), horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = "Current Month: ${dateState.value}")
+        HorizontalPager(state = pagerState, modifier = Modifier.fillMaxHeight(0.8f)) { pageNumber ->
+            val currentContainer = bucketsState.value[pageNumber]
+            if(currentContainer.isEmpty()) {
+                Text(text = "No transactions were made within this month.")
+            }
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                //This component should also hold the state for the inner internal items
+                LazyColumn {
+                    items(currentContainer) { container ->
                         Text(
-                            "No buckets for this category yet!",
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.padding(4.dp)
+                            text = when (container.containerType) {
+                                BucketType.INFLOW -> "Inflow"
+                                BucketType.OUTFLOW -> "Outflow"
+                                BucketType.FUND -> "Fund"
+                            },
+                            fontSize = 32.sp,
+                            modifier = Modifier.padding(8.dp)
                         )
-                    }
-                } else {
-                    container.buckets.forEach { bucket ->
-                        BucketCard(
-                            name = bucket.value.bucketName,
-                            estimatedAmount = bucket.value.estimatedAmount,
-                            actualAmount = bucket.value.transactions.sumOf { it.transactionAmount.toDouble() },
-                            onClick = fun() {
-                                component.onItemClicked(bucket.value)
+                        if (container.buckets.isEmpty()) {
+                            Card(
+                                modifier = Modifier.fillMaxWidth(0.8f)
+                                    .padding(16.dp).height(IntrinsicSize.Min), elevation = 4.dp
+                            ) {
+                                Text(
+                                    "No buckets for this category yet!",
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.padding(4.dp)
+                                )
                             }
-                        )
+                        } else {
+                            container.buckets.forEach { bucket ->
+                                BucketCard(
+                                    name = bucket.value.bucketName,
+                                    estimatedAmount = bucket.value.estimatedAmount,
+                                    actualAmount = bucket.value.transactions.sumOf { it.transactionAmount.toDouble() },
+                                    onClick = fun() {
+                                        component.onItemClicked(bucket.value)
+                                    }
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/views/ContainerView.kt
+++ b/composeApp/src/commonMain/kotlin/views/ContainerView.kt
@@ -1,90 +1,154 @@
 package views
 
-import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.Card
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import components.BucketCard
-import kotlinx.coroutines.flow.collect
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
 import models.BucketType
 import viewmodels.ListComponent
 
-@OptIn(ExperimentalFoundationApi::class)
+val months = mapOf(
+    1 to "January",
+    2 to "February",
+    3 to "March",
+    4 to "April",
+    5 to "May",
+    6 to "June",
+    7 to "July",
+    8 to "August",
+    9 to "September",
+    10 to "October",
+    11 to "November",
+    12 to "December"
+)
+
+val years = (2023..Clock.System.todayIn(TimeZone.currentSystemDefault()).year).toList()
 @Composable
 fun ContainerView(component: ListComponent) { //Really, this is a bucket of buckets.
     val bucketsState = component.model.subscribeAsState()
     val dateState = component.currentDate.subscribeAsState()
-    val oldPageNumber = remember { mutableStateOf(1) }
-    val pagerState = rememberPagerState(initialPage = 1, pageCount = { 3 })
-    LaunchedEffect(pagerState) {
-        snapshotFlow { pagerState.currentPage }.collect { page ->
-            component.changeMonth(oldPageNumber.value, page)
-            oldPageNumber.value = page
-        }
-    }
-    Column(modifier = Modifier.fillMaxHeight(), horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(text = "Current Month: ${dateState.value}")
-        HorizontalPager(state = pagerState, modifier = Modifier.fillMaxHeight(0.8f)) { pageNumber ->
-            val currentContainer = bucketsState.value[pageNumber]
-            if(currentContainer.isEmpty()) {
-                Text(text = "No transactions were made within this month.")
+    val changeMonthDropdown = remember { mutableStateOf(false) }
+    val changeYearDropdown = remember { mutableStateOf(false) }
+    Column(
+        modifier = Modifier.fillMaxHeight(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row {
+            Card(modifier = Modifier.padding(8.dp)) {
+                Text(
+                    text = dateState.value.month.name,
+                    fontSize = 24.sp,
+                    modifier = Modifier.clickable { changeMonthDropdown.value = !changeMonthDropdown.value })
+                if (changeMonthDropdown.value)
+                    Surface {
+                        DropdownMenu(
+                            expanded = changeMonthDropdown.value,
+                            onDismissRequest = {
+                                changeMonthDropdown.value = !changeMonthDropdown.value
+                            }) {
+                            months.forEach { (monthIndex, monthName) ->
+                                DropdownMenuItem(onClick = {
+                                    component.updateCurrentDate(monthIndex, dateState.value.year)
+                                    changeMonthDropdown.value = false
+                                }) {
+                                    Text(text = monthName)
+                                }
+                            }
+                        }
+                    }
             }
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                //This component should also hold the state for the inner internal items
-                LazyColumn {
-                    items(currentContainer) { container ->
-                        Text(
-                            text = when (container.containerType) {
-                                BucketType.INFLOW -> "Inflow"
-                                BucketType.OUTFLOW -> "Outflow"
-                                BucketType.FUND -> "Fund"
-                            },
-                            fontSize = 32.sp,
-                            modifier = Modifier.padding(8.dp)
-                        )
-                        if (container.buckets.isEmpty()) {
-                            Card(
-                                modifier = Modifier.fillMaxWidth(0.8f)
-                                    .padding(16.dp).height(IntrinsicSize.Min), elevation = 4.dp
-                            ) {
-                                Text(
-                                    "No buckets for this category yet!",
-                                    textAlign = TextAlign.Center,
-                                    modifier = Modifier.padding(4.dp)
-                                )
+
+            Card(modifier = Modifier.padding(8.dp)) {
+                Text(
+                    text = dateState.value.year.toString(),
+                    fontSize = 24.sp,
+                    modifier = Modifier.clickable { changeYearDropdown.value = !changeYearDropdown.value })
+                if (changeYearDropdown.value)
+                    Surface {
+                        DropdownMenu(
+                            expanded = changeYearDropdown.value,
+                            onDismissRequest = {
+                                changeYearDropdown.value = !changeYearDropdown.value
+                            }) {
+                            years.forEach { year ->
+                                DropdownMenuItem(onClick = {
+                                    component.updateCurrentDate(dateState.value.monthNumber, year)
+                                    changeYearDropdown.value = false
+                                }) {
+                                    Text(text = year.toString())
+                                }
                             }
-                        } else {
-                            container.buckets.forEach { bucket ->
-                                BucketCard(
-                                    name = bucket.value.bucketName,
-                                    estimatedAmount = bucket.value.estimatedAmount,
-                                    actualAmount = bucket.value.transactions.sumOf { it.transactionAmount.toDouble() },
-                                    onClick = fun() {
-                                        component.onItemClicked(bucket.value)
-                                    }
-                                )
-                            }
+                        }
+                    }
+            }
+        }
+        if (bucketsState.value.isEmpty()) {
+            Text(text = "No transactions were made within this month.")
+        }
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            //This component should also hold the state for the inner internal items
+            LazyColumn {
+                items(bucketsState.value) { container ->
+                    Text(
+                        text = when (container.containerType) {
+                            BucketType.INFLOW -> "Inflow"
+                            BucketType.OUTFLOW -> "Outflow"
+                            BucketType.FUND -> "Fund"
+                        },
+                        fontSize = 32.sp,
+                        modifier = Modifier.padding(8.dp)
+                    )
+                    if (container.buckets.isEmpty()) {
+                        Card(
+                            modifier = Modifier.fillMaxWidth(0.8f)
+                                .padding(16.dp).height(IntrinsicSize.Min), elevation = 4.dp
+                        ) {
+                            Text(
+                                "No buckets for this category yet!",
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.padding(4.dp)
+                            )
+                        }
+                    } else {
+                        container.buckets.forEach { bucket ->
+                            BucketCard(
+                                name = bucket.value.bucketName,
+                                estimatedAmount = bucket.value.estimatedAmount,
+                                actualAmount = bucket.value.transactions.sumOf { it.transactionAmount.toDouble() },
+                                onClick = fun() {
+                                    component.onItemClicked(bucket.value)
+                                }
+                            )
                         }
                     }
                 }

--- a/shared/src/commonMain/sqldelight/com/technology626/budgyt/functions/Transaction.sq
+++ b/shared/src/commonMain/sqldelight/com/technology626/budgyt/functions/Transaction.sq
@@ -20,6 +20,13 @@ getTransactionsForBucketId:
     FROM BudgetTransaction
     WHERE bucket_id = ?;
 
+getTransactionsForBucketForRange:
+    SELECT id, transaction_amount, transaction_note, transaction_date, bucket_id
+    FROM BudgetTransaction
+    WHERE bucket_id = ?
+    AND transaction_date >= ?
+    AND transaction_date < ?;
+
 getTransactionById:
     SELECT id, transaction_amount, transaction_note, transaction_date, bucket_id
     FROM BudgetTransaction

--- a/shared/src/commonMain/sqldelight/com/technology626/budgyt/functions/Transaction.sq
+++ b/shared/src/commonMain/sqldelight/com/technology626/budgyt/functions/Transaction.sq
@@ -25,7 +25,7 @@ getTransactionsForBucketForRange:
     FROM BudgetTransaction
     WHERE bucket_id = ?
     AND transaction_date >= ?
-    AND transaction_date < ?;
+    AND transaction_date <= ?;
 
 getTransactionById:
     SELECT id, transaction_amount, transaction_note, transaction_date, bucket_id


### PR DESCRIPTION
Currently, each bucket is "global", which means its estimate and name carries across (and is visible) in all months/years. This will likely be changed in a future update but for now is going to be as-is.

Fixes #8 - sort of.