### PR TITLE
Fix Number Implementation by Migrating to BigDecimal

### DIFF
--- a/composeApp/src/commonMain/kotlin/components/BucketCard.kt
+++ b/composeApp/src/commonMain/kotlin/components/BucketCard.kt
@@ -19,13 +19,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import java.text.NumberFormat
 import java.util.Locale
+import java.math.BigDecimal
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun BucketCard(
     name: String,
-    actualAmount: Double,
-    estimatedAmount: Float,
+    actualAmount: BigDecimal,
+    estimatedAmount: BigDecimal,
     onClick: () -> Unit = {}
 ) {
     MaterialTheme {

--- a/composeApp/src/commonMain/kotlin/components/TransactionInputComponent.kt
+++ b/composeApp/src/commonMain/kotlin/components/TransactionInputComponent.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlin.math.abs
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 @Composable
 fun TransactionInputComponent(modifier: Modifier = Modifier, value: BigDecimal, onInputChange: (newValue: BigDecimal) -> Unit) {
@@ -23,18 +24,17 @@ fun TransactionInputComponent(modifier: Modifier = Modifier, value: BigDecimal, 
         singleLine = true,
         onValueChange = { newAmount ->
             var updatedValue = value
-            // if(newAmount.text.length - newAmount.text.indexOf('.') <= 2) {
-            //     updatedValue /= 10
-            //     if(abs(updatedValue - 0) < 0.01) {
-            //         updatedValue = 0.0
-            //     }
-            // } else {
-            //     val lastCharacter = newAmount.text[newAmount.text.length - 1]
-            //     if(lastCharacter.isDigit()) {
-            //         updatedValue *= 10
-            //         updatedValue += "0.0$lastCharacter".toFloat()
-            //     }
-            // }
+            if(newAmount.text.length - newAmount.text.indexOf('.') <= 2) {
+                updatedValue = updatedValue.movePointLeft(1) //We need to force the scale to be 2?
+                updatedValue = updatedValue.setScale(2, RoundingMode.DOWN)
+            } else {
+                val lastCharacter = newAmount.text[newAmount.text.length - 1]
+                if(lastCharacter.isDigit()) {
+                    updatedValue = updatedValue.movePointRight(1) //No need to update scale when moving right.
+                    val newValue = BigDecimal("0.0$lastCharacter") //TODO: Is this jank?
+                    updatedValue += newValue
+                }
+            }
             onInputChange(updatedValue)
         },
         keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number)

--- a/composeApp/src/commonMain/kotlin/components/TransactionInputComponent.kt
+++ b/composeApp/src/commonMain/kotlin/components/TransactionInputComponent.kt
@@ -9,10 +9,10 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlin.math.abs
+import java.math.BigDecimal
 
-//TODO: Replace implementation of currency with BigDecimal - float/double are prone to error
 @Composable
-fun TransactionInputComponent(modifier: Modifier = Modifier, value: Float, onInputChange: (newValue: Float) -> Unit) {
+fun TransactionInputComponent(modifier: Modifier = Modifier, value: BigDecimal, onInputChange: (newValue: BigDecimal) -> Unit) {
     val formatted = GLOBAL_FORMATTER.format(value)
     TextField(
         value = TextFieldValue(
@@ -22,22 +22,20 @@ fun TransactionInputComponent(modifier: Modifier = Modifier, value: Float, onInp
         modifier = modifier,
         singleLine = true,
         onValueChange = { newAmount ->
-            var updatedValue = value.toDouble()
-            if(abs(GLOBAL_FORMATTER.parse(newAmount.text).toDouble() - updatedValue) >= 0.001) {
-                if(newAmount.text.length - newAmount.text.indexOf('.') <= 2) {
-                    updatedValue /= 10
-                    if(abs(updatedValue - 0) < 0.01) {
-                        updatedValue = 0.0
-                    }
-                } else {
-                    val lastCharacter = newAmount.text[newAmount.text.length - 1]
-                    if(lastCharacter.isDigit()) {
-                        updatedValue *= 10
-                        updatedValue += "0.0$lastCharacter".toFloat()
-                    }
-                }
-                onInputChange(updatedValue.toFloat())
-            }
+            var updatedValue = value
+            // if(newAmount.text.length - newAmount.text.indexOf('.') <= 2) {
+            //     updatedValue /= 10
+            //     if(abs(updatedValue - 0) < 0.01) {
+            //         updatedValue = 0.0
+            //     }
+            // } else {
+            //     val lastCharacter = newAmount.text[newAmount.text.length - 1]
+            //     if(lastCharacter.isDigit()) {
+            //         updatedValue *= 10
+            //         updatedValue += "0.0$lastCharacter".toFloat()
+            //     }
+            // }
+            onInputChange(updatedValue)
         },
         keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number)
     )

--- a/composeApp/src/commonMain/kotlin/viewmodels/EditBucketComponent.kt
+++ b/composeApp/src/commonMain/kotlin/viewmodels/EditBucketComponent.kt
@@ -7,16 +7,17 @@ import com.technology626.budgyt.budgyt
 import models.Bucket
 import models.BucketType
 import java.util.UUID
+import java.math.BigDecimal
 
 interface EditBucketComponent {
     val bucket: Bucket?
-    fun addBucket(bucketName: String, bucketType: BucketType, bucketEstimate: Float)
+    fun addBucket(bucketName: String, bucketType: BucketType, bucketEstimate: BigDecimal)
 
     fun editBucket(
         bucketId: UUID,
         bucketName: String,
         bucketType: BucketType,
-        bucketEstimate: Float
+        bucketEstimate: BigDecimal
     )
 }
 
@@ -26,13 +27,13 @@ class DefaultEditBucketComponent(
     private val database: budgyt,
     val onAddBucket: (bucketId: UUID) -> Unit
 ) : EditBucketComponent, ComponentContext by componentContext {
-    override fun addBucket(bucketName: String, bucketType: BucketType, bucketEstimate: Float) {
+    override fun addBucket(bucketName: String, bucketType: BucketType, bucketEstimate: BigDecimal) {
         val newBucketId = UUID.randomUUID()
         database.bucketQueries.addBucket(
             id = newBucketId,
             bucket_name = bucketName,
             bucket_type = bucketType,
-            bucket_estimate = bucketEstimate.toDouble()
+            bucket_estimate = bucketEstimate
         )
         onAddBucket(newBucketId)
     }
@@ -41,12 +42,12 @@ class DefaultEditBucketComponent(
         bucketId: UUID,
         bucketName: String,
         bucketType: BucketType,
-        bucketEstimate: Float
+        bucketEstimate: BigDecimal
     ) {
         database.bucketQueries.editBucket(
             bucket_name = bucketName,
             bucket_type = bucketType,
-            bucket_estimate = bucketEstimate.toDouble(),
+            bucket_estimate = bucketEstimate,
             id = bucketId
         )
         onAddBucket(bucketId)

--- a/composeApp/src/commonMain/kotlin/viewmodels/EditTransactionComponent.kt
+++ b/composeApp/src/commonMain/kotlin/viewmodels/EditTransactionComponent.kt
@@ -7,6 +7,7 @@ import models.Bucket
 import models.Transaction
 import models.toApplicationDataModel
 import java.util.UUID
+import java.math.BigDecimal
 
 enum class TransactionEditType {
     CREATE,
@@ -19,7 +20,7 @@ interface EditTransactionComponent {
     val listBuckets: List<Bucket>
     fun createTransaction(
         bucketId: UUID,
-        transactionAmount: Float,
+        transactionAmount: BigDecimal,
         transactionNote: String,
         transactionDate: LocalDate
     )
@@ -44,7 +45,7 @@ class DefaultEditTransactionComponent(
 
     override fun createTransaction(
         bucketId: UUID,
-        transactionAmount: Float,
+        transactionAmount: BigDecimal,
         transactionNote: String,
         transactionDate: LocalDate
     ) {
@@ -54,7 +55,7 @@ class DefaultEditTransactionComponent(
             bucket_id = bucketId,
             transaction_date = transactionDate,
             transaction_note = transactionNote,
-            transaction_amount = transactionAmount.toDouble()
+            transaction_amount = transactionAmount
         )
         onTransactionUpdated(TransactionEditType.CREATE, transactionId, bucketId)
     }
@@ -68,7 +69,7 @@ class DefaultEditTransactionComponent(
             throw Exception("ERROR: Old transaction id is not the same as new transaction id! This is unexpected behavior.")
         }
         database.transactionQueries.updateTransaction(
-            transaction_amount = newTransaction.transactionAmount.toDouble(),
+            transaction_amount = newTransaction.transactionAmount,
             transaction_note = newTransaction.note,
             transaction_date = newTransaction.transactionDate,
             bucket_id = bucketId,

--- a/composeApp/src/commonMain/kotlin/views/ContainerView.kt
+++ b/composeApp/src/commonMain/kotlin/views/ContainerView.kt
@@ -37,6 +37,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 import models.BucketType
 import viewmodels.ListComponent
+import java.math.BigDecimal
 
 val months = mapOf(
     1 to "January",
@@ -150,7 +151,7 @@ fun ContainerView(component: ListComponent) { //Really, this is a bucket of buck
                             BucketCard(
                                 name = bucket.value.bucketName,
                                 estimatedAmount = bucket.value.estimatedAmount,
-                                actualAmount = bucket.value.transactions.sumOf { it.transactionAmount.toDouble() },
+                                actualAmount = bucket.value.transactions.sumOf { it.transactionAmount },
                                 onClick = fun() {
                                     component.onItemClicked(bucket.value)
                                 }

--- a/composeApp/src/commonMain/kotlin/views/EditBucketView.kt
+++ b/composeApp/src/commonMain/kotlin/views/EditBucketView.kt
@@ -19,13 +19,14 @@ import models.BucketType
 import viewmodels.EditBucketComponent
 import java.text.NumberFormat
 import java.util.Locale
+import java.math.BigDecimal
 
 @Composable
 fun EditBucketView(component: EditBucketComponent) {
     val bucketName = remember { mutableStateOf(component.bucket?.bucketName ?: "") }
     val bucketType = remember { mutableStateOf(component.bucket?.bucketType ?: BucketType.INFLOW) }
     val bucketTypeExpanded = remember { mutableStateOf(false) }
-    val bucketEstimateAmount = remember { mutableStateOf(component.bucket?.estimatedAmount ?: 0f) }
+    val bucketEstimateAmount = remember { mutableStateOf(component.bucket?.estimatedAmount ?: BigDecimal(0.0)) }
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(text = "Bucket Name", fontSize = 24.sp)
         TextField(

--- a/composeApp/src/commonMain/kotlin/views/EditTransactionView.kt
+++ b/composeApp/src/commonMain/kotlin/views/EditTransactionView.kt
@@ -33,12 +33,13 @@ import viewmodels.EditTransactionComponent
 import java.text.NumberFormat
 import java.util.Locale
 import java.util.UUID
+import java.math.BigDecimal
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditTransactionView(component: EditTransactionComponent) {
     val transactionAmount =
-        remember { mutableStateOf(component.currentTransaction?.transactionAmount ?: 0f) }
+        remember { mutableStateOf(component.currentTransaction?.transactionAmount ?: BigDecimal(0.0)) }
     val transactionNote = remember { mutableStateOf(component.currentTransaction?.note ?: "") }
     val transactionDate =
         rememberDatePickerState(

--- a/shared/src/commonMain/kotlin/Database.kt
+++ b/shared/src/commonMain/kotlin/Database.kt
@@ -1,5 +1,6 @@
 import adapters.LocalDateAdapter
 import adapters.UUIDAdapter
+import adapters.BigDecimalAdapter
 import app.cash.sqldelight.EnumColumnAdapter
 import app.cash.sqldelight.db.SqlDriver
 import com.technology626.budgyt.Bucket
@@ -14,11 +15,13 @@ fun createDatabase(driverFactory: DriverFactory): budgyt {
     val driver = driverFactory.createDriver()
     val database = budgyt(driver, BucketAdapter = Bucket.Adapter(
         idAdapter = UUIDAdapter,
-        bucket_typeAdapter = EnumColumnAdapter()
+        bucket_typeAdapter = EnumColumnAdapter(),
+        bucket_estimateAdapter = BigDecimalAdapter
     ), BudgetTransactionAdapter = BudgetTransaction.Adapter(
         idAdapter = UUIDAdapter,
         bucket_idAdapter = UUIDAdapter,
-        transaction_dateAdapter = LocalDateAdapter
+        transaction_dateAdapter = LocalDateAdapter,
+        transaction_amountAdapter = BigDecimalAdapter
     ))
 
     return database

--- a/shared/src/commonMain/kotlin/adapters/BigDecimalAdapter.kt
+++ b/shared/src/commonMain/kotlin/adapters/BigDecimalAdapter.kt
@@ -3,13 +3,13 @@ package adapters
 import app.cash.sqldelight.ColumnAdapter
 import java.math.BigDecimal
 
-val BigDecimalAdapter = object : ColumnAdapter<BigDecimal, Double> {
-    override fun decode(databaseValue: Double): BigDecimal {
+val BigDecimalAdapter = object : ColumnAdapter<BigDecimal, String> {
+    override fun decode(databaseValue: String): BigDecimal {
         return BigDecimal(databaseValue)
     }
 
-    override fun encode(value: BigDecimal): Double {
-        return BigDecimal(value).setScale(2, BigDecimal.ROUND_HALF_UP).toDouble()
+    override fun encode(value: BigDecimal): String {
+        return value.toString()
     }
 
 }

--- a/shared/src/commonMain/kotlin/adapters/BigDecimalAdapter.kt
+++ b/shared/src/commonMain/kotlin/adapters/BigDecimalAdapter.kt
@@ -1,0 +1,15 @@
+package adapters
+
+import app.cash.sqldelight.ColumnAdapter
+import java.math.BigDecimal
+
+val BigDecimalAdapter = object : ColumnAdapter<BigDecimal, Double> {
+    override fun decode(databaseValue: Double): BigDecimal {
+        return BigDecimal(databaseValue)
+    }
+
+    override fun encode(value: BigDecimal): Double {
+        return BigDecimal(value).setScale(2, BigDecimal.ROUND_HALF_UP).toDouble()
+    }
+
+}

--- a/shared/src/commonMain/kotlin/models/BigDecimalSerializer.kt
+++ b/shared/src/commonMain/kotlin/models/BigDecimalSerializer.kt
@@ -1,0 +1,23 @@
+package models
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.math.BigDecimal
+
+object BigDecimalSerializer: KSerializer<BigDecimal> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("BigDecimal", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): BigDecimal {
+        return BigDecimal(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: BigDecimal) {
+        encoder.encodeString(value.toString())
+    }
+
+}

--- a/shared/src/commonMain/kotlin/models/Bucket.kt
+++ b/shared/src/commonMain/kotlin/models/Bucket.kt
@@ -4,6 +4,7 @@ import com.technology626.budgyt.Bucket
 import com.technology626.budgyt.budgyt
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
+import java.math.BigDecimal
 import java.time.Month
 import java.util.UUID
 
@@ -16,7 +17,8 @@ data class Bucket(
     @Serializable(with = JavaUUIDSerializer::class)
     val id: UUID,
     val bucketName: String,
-    val estimatedAmount: Float,
+    @Serializable(with = BigDecimalSerializer::class)
+    val estimatedAmount: BigDecimal,
     val transactions: List<Transaction>,
     val bucketType: BucketType
 )
@@ -25,7 +27,7 @@ fun Bucket.toApplicationDataModel(budgyt: budgyt): models.Bucket {
     return Bucket(
         id = this.id,
         bucketName = bucket_name,
-        estimatedAmount = bucket_estimate.toFloat(),
+        estimatedAmount = bucket_estimate,
         bucketType = bucket_type, //TODO: Make coroutine context actually work
         transactions = budgyt.transactionQueries.getTransactionsForBucketId(this.id).executeAsList()
             .map { budgetTransaction -> budgetTransaction.toApplicationDataModel() }
@@ -47,7 +49,7 @@ fun Bucket.toApplicationDataModelOfMonth(budgyt: budgyt, currentDate: LocalDate)
     return Bucket(
         id = this.id,
         bucketName = bucket_name,
-        estimatedAmount = bucket_estimate.toFloat(),
+        estimatedAmount = bucket_estimate,
         bucketType = bucket_type,
         transactions = budgyt.transactionQueries.getTransactionsForBucketForRange(
             this.id, lowEnd, highEnd
@@ -59,7 +61,7 @@ fun Bucket.toApplicationDataModel(): models.Bucket {
     return Bucket(
         id = this.id,
         bucketName = bucket_name,
-        estimatedAmount = bucket_estimate.toFloat(),
+        estimatedAmount = bucket_estimate,
         bucketType = bucket_type,
         transactions = emptyList()
     )

--- a/shared/src/commonMain/kotlin/models/Transaction.kt
+++ b/shared/src/commonMain/kotlin/models/Transaction.kt
@@ -5,12 +5,14 @@ import com.technology626.budgyt.BudgetTransaction
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 import java.util.UUID
+import java.math.BigDecimal
 
 @Serializable
 data class Transaction(
     @Serializable(with = JavaUUIDSerializer::class)
     val id: UUID,
-    val transactionAmount: Float,
+    @Serializable(with = BigDecimalSerializer::class)
+    val transactionAmount: BigDecimal,
     val note: String,
     val transactionDate: LocalDate,
     @Serializable(with = JavaUUIDSerializer::class)
@@ -20,7 +22,7 @@ data class Transaction(
 fun BudgetTransaction.toApplicationDataModel(): Transaction {
     return Transaction(
         id = id,
-        transactionAmount = transaction_amount.toFloat(),
+        transactionAmount = transaction_amount,
         note = transaction_note,
         transactionDate = transaction_date,
         bucketId = bucket_id

--- a/shared/src/commonMain/sqldelight/com/technology626/budgyt/Bucket.sq
+++ b/shared/src/commonMain/sqldelight/com/technology626/budgyt/Bucket.sq
@@ -1,9 +1,10 @@
 import java.util.UUID;
 import models.BucketType;
+import java.math.BigDecimal;
 
 CREATE TABLE Bucket(
     id TEXT AS UUID PRIMARY KEY NOT NULL,
     bucket_name TEXT NOT NULL,
     bucket_type TEXT AS BucketType NOT NULL,
-    bucket_estimate REAL NOT NULL DEFAULT 0
+    bucket_estimate REAL AS BigDecimal NOT NULL DEFAULT 0
 );

--- a/shared/src/commonMain/sqldelight/com/technology626/budgyt/Bucket.sq
+++ b/shared/src/commonMain/sqldelight/com/technology626/budgyt/Bucket.sq
@@ -6,5 +6,5 @@ CREATE TABLE Bucket(
     id TEXT AS UUID PRIMARY KEY NOT NULL,
     bucket_name TEXT NOT NULL,
     bucket_type TEXT AS BucketType NOT NULL,
-    bucket_estimate REAL AS BigDecimal NOT NULL DEFAULT 0
+    bucket_estimate TEXT AS BigDecimal NOT NULL DEFAULT 0
 );

--- a/shared/src/commonMain/sqldelight/com/technology626/budgyt/Transaction.sq
+++ b/shared/src/commonMain/sqldelight/com/technology626/budgyt/Transaction.sq
@@ -1,9 +1,10 @@
 import java.util.UUID;
 import kotlinx.datetime.LocalDate;
+import java.math.BigDecimal;
 
 CREATE TABLE BudgetTransaction (
     id TEXT AS UUID PRIMARY KEY NOT NULL,
-    transaction_amount REAL NOT NULL DEFAULT 0,
+    transaction_amount REAL AS BigDecimal NOT NULL DEFAULT 0,
     transaction_note TEXT NOT NULL DEFAULT '',
     transaction_date TEXT AS LocalDate NOT NULL,
     bucket_id TEXT AS UUID NOT NULL,

--- a/shared/src/commonMain/sqldelight/com/technology626/budgyt/Transaction.sq
+++ b/shared/src/commonMain/sqldelight/com/technology626/budgyt/Transaction.sq
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 
 CREATE TABLE BudgetTransaction (
     id TEXT AS UUID PRIMARY KEY NOT NULL,
-    transaction_amount REAL AS BigDecimal NOT NULL DEFAULT 0,
+    transaction_amount TEXT AS BigDecimal NOT NULL DEFAULT 0,
     transaction_note TEXT NOT NULL DEFAULT '',
     transaction_date TEXT AS LocalDate NOT NULL,
     bucket_id TEXT AS UUID NOT NULL,


### PR DESCRIPTION
One point of potential confusion is in the storage of money as text within our system:
1. Decimals are imprecise values and I don't want to take the risk of an error occurring here.
2. The `.doubleValue()` method for some reason is not behaving properly in the adapter - so I had to resort to using Strings as a base instead.

Fixes #34 