### PR TITLE
Overhaul Fund Buckets With Respect to Gain/Loss

### DIFF
--- a/composeApp/src/commonMain/kotlin/TransactionColorHelper.kt
+++ b/composeApp/src/commonMain/kotlin/TransactionColorHelper.kt
@@ -1,10 +1,13 @@
 import androidx.compose.ui.graphics.Color
 import java.math.BigDecimal
 
-fun returnMonetaryValueColor(value: BigDecimal): Color {
+
+val DARKER_GREEN = Color(0, 215, 57)
+
+fun returnMonetaryValueColor(value: BigDecimal, defaultPositiveColor: Color = DARKER_GREEN): Color {
     return when {
         value < BigDecimal(0) -> Color.Red
-        value > BigDecimal(0) -> Color(0, 215, 57)
+        value > BigDecimal(0) -> defaultPositiveColor
         else -> Color.Gray
     }
 }

--- a/composeApp/src/commonMain/kotlin/components/InflowOutflowComponent.kt
+++ b/composeApp/src/commonMain/kotlin/components/InflowOutflowComponent.kt
@@ -37,15 +37,15 @@ fun InflowOutflowComponent(
             Text(text = GLOBAL_FORMATTER.format(totalOutflow))
         }
         Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(text = "Total Funding:")
+            Text(text = "Total Value of Funds:")
             Text(text = GLOBAL_FORMATTER.format(totalFunding))
         }
         Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
             Text(text = "Net Income Flow:", fontSize = 18.sp)
             Text(
-                text = GLOBAL_FORMATTER.format(totalInflow - totalOutflow - totalFunding),
+                text = GLOBAL_FORMATTER.format(totalInflow - totalOutflow),
                 fontSize = 18.sp,
-                color = returnMonetaryValueColor(totalInflow - totalOutflow - totalFunding)
+                color = returnMonetaryValueColor(totalInflow - totalOutflow)
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/components/TransactionInputComponent.kt
+++ b/composeApp/src/commonMain/kotlin/components/TransactionInputComponent.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
-import kotlin.math.abs
 import java.math.BigDecimal
 import java.math.RoundingMode
 
@@ -31,8 +30,14 @@ fun TransactionInputComponent(modifier: Modifier = Modifier, value: BigDecimal, 
                 val lastCharacter = newAmount.text[newAmount.text.length - 1]
                 if(lastCharacter.isDigit()) {
                     updatedValue = updatedValue.movePointRight(1) //No need to update scale when moving right.
-                    val newValue = BigDecimal("0.0$lastCharacter") //TODO: Is this jank?
-                    updatedValue += newValue
+                    val newValue = BigDecimal("0.0$updatedValue")
+                    if(updatedValue >= BigDecimal(0)) {
+                        updatedValue += newValue
+                    } else {
+                        updatedValue -= newValue
+                    }
+                } else if (lastCharacter == '-') {
+                    updatedValue = updatedValue.negate()
                 }
             }
             onInputChange(updatedValue)

--- a/composeApp/src/commonMain/kotlin/components/TransactionInputComponent.kt
+++ b/composeApp/src/commonMain/kotlin/components/TransactionInputComponent.kt
@@ -12,7 +12,11 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 
 @Composable
-fun TransactionInputComponent(modifier: Modifier = Modifier, value: BigDecimal, onInputChange: (newValue: BigDecimal) -> Unit) {
+fun TransactionInputComponent(
+    modifier: Modifier = Modifier,
+    value: BigDecimal,
+    onInputChange: (newValue: BigDecimal) -> Unit
+) {
     val formatted = GLOBAL_FORMATTER.format(value)
     TextField(
         value = TextFieldValue(
@@ -23,15 +27,16 @@ fun TransactionInputComponent(modifier: Modifier = Modifier, value: BigDecimal, 
         singleLine = true,
         onValueChange = { newAmount ->
             var updatedValue = value
-            if(newAmount.text.length - newAmount.text.indexOf('.') <= 2) {
+            if (newAmount.text.length - newAmount.text.indexOfFirst { char -> char == '.' } <= 2) {
                 updatedValue = updatedValue.movePointLeft(1) //We need to force the scale to be 2?
                 updatedValue = updatedValue.setScale(2, RoundingMode.DOWN)
             } else {
                 val lastCharacter = newAmount.text[newAmount.text.length - 1]
-                if(lastCharacter.isDigit()) {
-                    updatedValue = updatedValue.movePointRight(1) //No need to update scale when moving right.
-                    val newValue = BigDecimal("0.0$updatedValue")
-                    if(updatedValue >= BigDecimal(0)) {
+                if (lastCharacter.isDigit()) {
+                    updatedValue =
+                        updatedValue.movePointRight(1) //No need to update scale when moving right.
+                    val newValue = BigDecimal("0.0$lastCharacter")
+                    if (updatedValue >= BigDecimal(0)) {
                         updatedValue += newValue
                     } else {
                         updatedValue -= newValue

--- a/composeApp/src/commonMain/kotlin/components/TransactionItem.kt
+++ b/composeApp/src/commonMain/kotlin/components/TransactionItem.kt
@@ -1,14 +1,12 @@
 package components
 
 import GLOBAL_FORMATTER
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Card
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -17,8 +15,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import models.Transaction
-import java.text.NumberFormat
-import java.util.Locale
+import returnMonetaryValueColor
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -26,7 +23,7 @@ fun TransactionItem(modifier: Modifier = Modifier, transaction: Transaction, onC
     Card(modifier = modifier, elevation = 4.dp, onClick = onClick) {
         Column(modifier = Modifier.fillMaxSize().padding(4.dp)) {
             Text(text = transaction.transactionDate.toString(), fontSize = 12.sp, fontWeight = FontWeight.Light)
-            Text(text = GLOBAL_FORMATTER.format(transaction.transactionAmount), fontSize = 18.sp, textAlign = TextAlign.End)
+            Text(text = GLOBAL_FORMATTER.format(transaction.transactionAmount), fontSize = 18.sp, textAlign = TextAlign.End, color = returnMonetaryValueColor(value = transaction.transactionAmount, defaultPositiveColor = MaterialTheme.colors.onBackground))
             Text(text = transaction.note)
         }
     }


### PR DESCRIPTION
- Funds are no longer counted against your gain/loss for the month - they should be treated completely separately
- Negative values are now allowed for all bucket types

Fixes #41 